### PR TITLE
[Server] remove `.clear()` method

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "search.exclude": {
+    ".yarn/": true
+  }
+}

--- a/packages/manatea/README.md
+++ b/packages/manatea/README.md
@@ -178,27 +178,13 @@ const server = cup.on(console.log);
 server();
 ```
 
-You can clear all the servers that are listening to a cup by calling `cup.clear()` on the cup itself:
-
-```js
-const server1 = cup.on(console.log);
-const server2 = cup.on(console.log);
-
-cup.clear(); // both server1 and server2 will be stopped
-```
-
 At any moment, you can check if a server is running by checking its `listening` attribute:
 
 ```js
-const server1 = cup.on(console.log);
-const server2 = cup.on(console.log);
+const server = cup.on(console.log);
 
-server1.listening; // true
-server2.listening; // true
+server.listening; // true
 
-server1();
-server1.listening; // false
-
-cup.clear();
-server2.listening; // false
+server();
+server.listening; // false
 ```

--- a/packages/manatea/__tests__/manatea.ts
+++ b/packages/manatea/__tests__/manatea.ts
@@ -24,26 +24,14 @@ describe('Manatea', () => {
   });
 
   it('should have clearable servers', async () => {
-    {
-      const cup = orderCup<number>(1);
-      const fn = jest.fn();
-      const server = cup.on(fn);
-      expect(server.listening).toBe(true);
-      server();
-      expect(server.listening).toBe(false);
-      await cup(2);
-      expect(fn).not.toHaveBeenCalled();
-    }
-    {
-      const cup = orderCup<number>(1);
-      const fn = jest.fn();
-      const server = cup.on(fn);
-      expect(server.listening).toBe(true);
-      cup.clear();
-      expect(server.listening).toBe(false);
-      await cup(2);
-      expect(fn).not.toHaveBeenCalled();
-    }
+    const cup = orderCup<number>(1);
+    const fn = jest.fn();
+    const server = cup.on(fn);
+    expect(server.listening).toBe(true);
+    server();
+    expect(server.listening).toBe(false);
+    await cup(2);
+    expect(fn).not.toHaveBeenCalled();
   });
 
   it('shouldn’t create infinite loops', async () => {

--- a/packages/manatea/src/index.ts
+++ b/packages/manatea/src/index.ts
@@ -31,7 +31,6 @@ export interface Cup<FlavoredTea extends Tea, UnflavoredTea extends Tea> {
     context?: Context,
   ): Promise<FlavoredTea>;
   on: (fn: Handler<FlavoredTea>) => Server;
-  clear: () => void;
 }
 
 export type Context = WeakSet<Cup<any, any>>;
@@ -102,8 +101,6 @@ export function orderCup<
     });
     return server as Server;
   };
-
-  cup.clear = () => handlers.clear();
 
   return cup;
 }


### PR DESCRIPTION
If we want to include selectors, .clear() makes the whole logic more complicated as you cannot be sure that a server defined in place will still be valid later, even if it wasn't manually cleared.