### PR TITLE
Drop listening **BREAKING CHANGE**

### DIFF
--- a/packages/manatea/README.md
+++ b/packages/manatea/README.md
@@ -185,17 +185,6 @@ const waiter = cup.on(console.log);
 waiter();
 ```
 
-At any moment, you can check if a waiter is running by checking its `listening` attribute:
-
-```js
-const waiter = cup.on(console.log);
-
-waiter.listening; // true
-
-waiter();
-waiter.listening; // false
-```
-
 ### Derived cup
 
 You can create a cup based on another one, or multiple other ones:

--- a/packages/manatea/__tests__/manatea.ts
+++ b/packages/manatea/__tests__/manatea.ts
@@ -27,9 +27,7 @@ describe('Manatea', () => {
     const cup = orderCup<number>(1);
     const fn = jest.fn();
     const waiter = cup.on(fn);
-    expect(waiter.listening).toBe(true);
     waiter();
-    expect(waiter.listening).toBe(false);
     await cup(2);
     expect(fn).not.toHaveBeenCalled();
   });

--- a/packages/manatea/src/index.ts
+++ b/packages/manatea/src/index.ts
@@ -17,7 +17,6 @@ type Handler<FlavoredTea extends Tea> = (
 ) => void;
 export interface Waiter {
   (): boolean;
-  listening: boolean;
 }
 
 type Order<FlavoredTea extends Tea, UnflavoredTea extends Tea> =
@@ -101,9 +100,6 @@ export function orderCup<
   cup.on = (fn: Handler<FlavoredTea>) => {
     handlers.add(fn);
     const waiter = () => handlers.delete(fn);
-    Object.defineProperty(waiter, 'listening', {
-      get: () => handlers.has(fn),
-    });
     return waiter as Waiter;
   };
 


### PR DESCRIPTION
This getter is not useful: the regular JS api doesn't expose it for EventTarget which means that it isn't required for JS. Why would it be required for us? 